### PR TITLE
add models, refactor migration

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -18,19 +18,19 @@ package main
 
 import (
 	"flag"
+	"github.com/dominikbraun/foodunit/migration"
 	"log"
-
-	"github.com/dominikbraun/foodunit/server"
 )
 
 // main sets up a server and invokes its RunMigration method.
 func main() {
-	dbURI := flag.String("db-uri", "", "root:root@(localhost:3306)/foodunit")
+	dbURI := flag.String("db-uri", "root:root@(localhost:3306)/foodunit", "URI used to connect to the db.")
+	drop := flag.Bool("drop", false, "This flag drops all tables before creation")
 	flag.Parse()
-	s, err := server.Setup("mysql", *dbURI, "")
+	s, err := migration.Setup("mysql", *dbURI)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	s.RunMigration()
+	s.Run(*drop)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,8 +24,8 @@ import (
 
 // main sets up a server and invokes its Run method.
 func main() {
-	clientURL := flag.String("client-url", "", "Specifies the URL of the client.")
-	dbURI := flag.String("db-uri", "", "root:root@(localhost:3306)/foodunit?parseTime=true")
+	clientURL := flag.String("client-url", "", "Specifies the URL of the client to start a proxy.")
+	dbURI := flag.String("db-uri", "root:root@(localhost:3306)/foodunit?parseTime=true", "URI used to connect to the db.")
 	flag.Parse()
 
 	s, err := server.Setup("mysql", *dbURI, *clientURL)

--- a/controllers/migration.go
+++ b/controllers/migration.go
@@ -12,24 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package server provides a server which exposes a REST API.
-package server
+// Package controllers provides various controllers for triggering the core logic.
+package controllers
 
 import (
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
-	"github.com/go-chi/render"
+	"github.com/dominikbraun/foodunit/storage"
 )
 
-// provideRouter provides a routing service instance.
-func provideRouter() *chi.Mux {
-	r := chi.NewRouter()
-	r.Use(
-		middleware.Logger,
-		middleware.DefaultCompress,
-		middleware.RedirectSlashes,
-		middleware.Recoverer,
-		render.SetContentType(render.ContentTypeJSON),
-	)
-	return r
+// Migration represents the handler for the initial set up of FootUnit
+type Migration struct {
+	Restaurants storage.RestaurantModel
+	Users       storage.UserModel
+}
+
+func (m *Migration) Migrate(drop bool) error {
+	if drop {
+		// ToDo
+	}
+
+	m.Restaurants.Migrate()
+	m.Users.Migrate()
+
+	return nil
 }

--- a/controllers/providers.go
+++ b/controllers/providers.go
@@ -27,10 +27,9 @@ func ProvideRESTController(r storage.RestaurantModel, u storage.UserModel) *REST
 }
 
 // provideMigrationController provides a controller instance for handling the initial FoodUnit set up.
-func ProvideMigrationController(r storage.RestaurantModel, u storage.UserModel) *Migration {
+func ProvideMigrationController(models ...storage.Model) *Migration {
 	controller := Migration{
-		Restaurants: r,
-		Users:       u,
+		Models: models,
 	}
 	return &controller
 }

--- a/controllers/providers.go
+++ b/controllers/providers.go
@@ -1,0 +1,36 @@
+// Copyright 2019 The FoodUnit Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package controllers provides various controllers for triggering the core logic.
+package controllers
+
+import "github.com/dominikbraun/foodunit/storage"
+
+// provideRESTController provides a controller instance for handing REST requests.
+func ProvideRESTController(r storage.RestaurantModel, u storage.UserModel) *REST {
+	controller := REST{
+		Restaurants: r,
+		Users:       u,
+	}
+	return &controller
+}
+
+// provideMigrationController provides a controller instance for handling the initial FoodUnit set up.
+func ProvideMigrationController(r storage.RestaurantModel, u storage.UserModel) *Migration {
+	controller := Migration{
+		Restaurants: r,
+		Users:       u,
+	}
+	return &controller
+}

--- a/dl/entities.go
+++ b/dl/entities.go
@@ -124,7 +124,7 @@ type Order struct {
 // Position represents one of multiple dishes contained in an user order.
 type Position struct {
 	Model
-	Dish        Dish   `db:"dish" json:"dish"`
+	Dish        Dish   `db:"dish_id" json:"dish_id"`
 	Alternative Dish   `db:"alternative" json:"alternative"`
 	Note        string `db:"note" json:"note"`
 }

--- a/dl/entities.go
+++ b/dl/entities.go
@@ -56,9 +56,8 @@ type Restaurant struct {
 // Category represents a menu section holding multiple dishes.
 type Category struct {
 	Model
-	Name    string `db:"name" json:"name"`
-	ImgPath string `db:"img_path" json:"img_path"`
-	Dishes  []Dish `db:"dishes" json:"dishes"`
+	Name   string `db:"name" json:"name"`
+	Dishes []Dish `db:"dishes" json:"dishes"`
 }
 
 // Dish represents a meal that is offered by a restaurant.

--- a/dl/entities.go
+++ b/dl/entities.go
@@ -65,7 +65,7 @@ type Dish struct {
 	Model
 	Name            string           `db:"name" json:"name"`
 	Description     string           `db:"description" json:"description"`
-	Price           uint8            `db:"price" json:"price"`
+	Price           uint             `db:"price" json:"price"`
 	IsUncertain     bool             `db:"is_uncertain" json:"is_uncertain"`
 	IsHealthy       bool             `db:"is_healthy" json:"is_healthy"`
 	Characteristics []Characteristic `db:"characteristics" json:"characteristics"`
@@ -84,7 +84,7 @@ type Variant struct {
 	Model
 	Value     string `db:"value" json:"value"`
 	IsDefault bool   `db:"is_default" json:"is_default"`
-	Price     int8   `db:"price" json:"price"`
+	Price     uint   `db:"price" json:"price"`
 }
 
 // User represents a person that creates offers and orders food.

--- a/dl/entities.go
+++ b/dl/entities.go
@@ -102,11 +102,11 @@ type User struct {
 // Offer represents an user's offer to order food for their friends or team.
 type Offer struct {
 	Model
-	Owner         User       `db:"owner" json:"owner"`
+	Owner         User       `db:"owner_user_id" json:"owner_user_id"`
 	Restaurant    Restaurant `db:"restaurant" json:"restaurant"`
 	ValidFrom     time.Time  `db:"valid_from" json:"valid_from"`
 	ValidTo       time.Time  `db:"valid_to" json:"valid_to"`
-	Responsible   User       `db:"responsible" json:"responsible"`
+	Responsible   User       `db:"responsible_user_id" json:"responsible_user_id"`
 	IsPlaced      bool       `db:"is_placed" json:"is_placed"`
 	ReadyAt       time.Time  `db:"ready_at" json:"ready_at"`
 	PaypalEnabled bool       `db:"paypal_enabled" json:"paypal_enabled"`

--- a/dl/entities.go
+++ b/dl/entities.go
@@ -116,7 +116,7 @@ type Offer struct {
 // Order represents an user's order that was placed as part of an order.
 type Order struct {
 	Model
-	User      User       `db:"user" json:"user"`
+	User      User       `db:"user_id" json:"user_id"`
 	Positions []Position `db:"positions" json:"positions"`
 	IsPaid    bool       `db:"is_paid" json:"is_paid"`
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -37,9 +37,10 @@ func Setup(driver, dsn string) (*Server, error) {
 		return nil, err
 	}
 
-	restaurantModel := mariadb.ProvideRestaurantModel(db)
-	userModel := mariadb.ProvideUserModel(db)
-	migrationController := controllers.ProvideMigrationController(restaurantModel, userModel)
+	migrationController := controllers.ProvideMigrationController(
+		mariadb.ProvideRestaurantModel(db),
+		mariadb.ProvideUserModel(db),
+		mariadb.ProvideCategoryModel(db))
 
 	s := Server{
 		controller: migrationController,

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -41,7 +41,10 @@ func Setup(driver, dsn string) (*Server, error) {
 		mariadb.ProvideRestaurantModel(db),
 		mariadb.ProvideUserModel(db),
 		mariadb.ProvideCategoryModel(db),
-		mariadb.ProvideDishModel(db))
+		mariadb.ProvideDishModel(db),
+		mariadb.ProvideCharacteristicModel(db),
+		mariadb.ProvideVariantModel(db),
+		mariadb.ProvideOfferModel(db))
 
 	s := Server{
 		controller: migrationController,

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -45,7 +45,8 @@ func Setup(driver, dsn string) (*Server, error) {
 		mariadb.ProvideCharacteristicModel(db),
 		mariadb.ProvideVariantModel(db),
 		mariadb.ProvideOfferModel(db),
-		mariadb.ProvideOrderModel(db))
+		mariadb.ProvideOrderModel(db),
+		mariadb.ProvidePositionModel(db))
 
 	s := Server{
 		controller: migrationController,

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -40,7 +40,8 @@ func Setup(driver, dsn string) (*Server, error) {
 	migrationController := controllers.ProvideMigrationController(
 		mariadb.ProvideRestaurantModel(db),
 		mariadb.ProvideUserModel(db),
-		mariadb.ProvideCategoryModel(db))
+		mariadb.ProvideCategoryModel(db),
+		mariadb.ProvideDishModel(db))
 
 	s := Server{
 		controller: migrationController,

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -44,7 +44,8 @@ func Setup(driver, dsn string) (*Server, error) {
 		mariadb.ProvideDishModel(db),
 		mariadb.ProvideCharacteristicModel(db),
 		mariadb.ProvideVariantModel(db),
-		mariadb.ProvideOfferModel(db))
+		mariadb.ProvideOfferModel(db),
+		mariadb.ProvideOrderModel(db))
 
 	s := Server{
 		controller: migrationController,

--- a/storage/mariadb/category_model.go
+++ b/storage/mariadb/category_model.go
@@ -12,33 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package controllers provides various controllers for triggering the core logic.
-package controllers
+// Package mariadb provides MariaDB-compatible model implementations.
+package mariadb
 
 import (
-	"github.com/dominikbraun/foodunit/storage"
+	"github.com/jmoiron/sqlx"
 )
 
-// Migration represents the handler for the initial set up of FootUnit
-type Migration struct {
-	Models []storage.Model
+// CategoryModel is a storage.CategoryModel implementation.
+type CategoryModel struct {
+	DB *sqlx.DB
 }
 
-func (m *Migration) Migrate(drop bool) error {
-	// ToDo: error handling
-	for _, model := range m.Models {
-		if drop {
-			err := model.Drop()
-			if err != nil {
-				return err
-			}
-		}
+// Migrate implements storage.Model.Migrate.
+func (c CategoryModel) Migrate() error {
+	query := `
+CREATE TABLE category (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+)`
+	_, err := c.DB.Exec(query)
+	return err
+}
 
-		err := model.Migrate()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+// Drop implements storage.Model.Drop.
+func (c CategoryModel) Drop() error {
+	return drop(c.DB, "category")
 }

--- a/storage/mariadb/category_model.go
+++ b/storage/mariadb/category_model.go
@@ -27,7 +27,7 @@ type CategoryModel struct {
 // Migrate implements storage.Model.Migrate.
 func (c CategoryModel) Migrate() error {
 	query := `
-CREATE TABLE category (
+CREATE TABLE categories (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) NOT NULL
 )`
@@ -37,5 +37,5 @@ CREATE TABLE category (
 
 // Drop implements storage.Model.Drop.
 func (c CategoryModel) Drop() error {
-	return drop(c.DB, "category")
+	return drop(c.DB, "categories")
 }

--- a/storage/mariadb/category_model.go
+++ b/storage/mariadb/category_model.go
@@ -28,8 +28,8 @@ type CategoryModel struct {
 func (c CategoryModel) Migrate() error {
 	query := `
 CREATE TABLE categories (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(50) NOT NULL
 )`
 	_, err := exec(c.DB, query)
 	return err

--- a/storage/mariadb/characteristic_model.go
+++ b/storage/mariadb/characteristic_model.go
@@ -30,9 +30,9 @@ func (c CharacteristicModel) Migrate() error {
 
 	query := `
 CREATE TABLE characteristics (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    multiple BOOLEAN NOT NULL
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(50) NOT NULL,
+	multiple BOOLEAN NOT NULL
 )`
 	_, err := exec(c.DB, query)
 	return err

--- a/storage/mariadb/characteristic_model.go
+++ b/storage/mariadb/characteristic_model.go
@@ -29,7 +29,7 @@ func (c CharacteristicModel) Migrate() error {
 	// ToDo: intermediate table to dish
 
 	query := `
-CREATE TABLE characteristic (
+CREATE TABLE characteristics (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) NOT NULL,
     multiple BOOLEAN NOT NULL
@@ -40,5 +40,5 @@ CREATE TABLE characteristic (
 
 // Drop implements storage.Model.Drop.
 func (c CharacteristicModel) Drop() error {
-	return drop(c.DB, "characteristic")
+	return drop(c.DB, "characteristics")
 }

--- a/storage/mariadb/characteristic_model.go
+++ b/storage/mariadb/characteristic_model.go
@@ -19,29 +19,26 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// DishModel is a storage.DishModel implementation.
-type DishModel struct {
+// CharacteristicModel is a storage.CharacteristicModel implementation.
+type CharacteristicModel struct {
 	DB *sqlx.DB
 }
 
 // Migrate implements storage.Model.Migrate.
-func (c DishModel) Migrate() error {
+func (c CharacteristicModel) Migrate() error {
+	// ToDo: intermediate table to dish
+
 	query := `
-CREATE TABLE dish (
+CREATE TABLE characteristic (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) NOT NULL,
-    description VARCHAR(200) NOT NULL,
-    price TINYINT UNSIGNED NOT NULL,
-    is_uncertain BOOLEAN NOT NULL,
-    is_healthy BOOLEAN NOT NULL,
-    category_id BIGINT UNSIGNED NOT NULL
+    multiple BOOLEAN NOT NULL
 )`
-
 	_, err := exec(c.DB, query)
 	return err
 }
 
 // Drop implements storage.Model.Drop.
-func (c DishModel) Drop() error {
-	return drop(c.DB, "dish")
+func (c CharacteristicModel) Drop() error {
+	return drop(c.DB, "characteristic")
 }

--- a/storage/mariadb/dish_model.go
+++ b/storage/mariadb/dish_model.go
@@ -28,13 +28,13 @@ type DishModel struct {
 func (c DishModel) Migrate() error {
 	query := `
 CREATE TABLE dishes (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    description VARCHAR(200) NOT NULL,
-    price TINYINT UNSIGNED NOT NULL,
-    is_uncertain BOOLEAN NOT NULL,
-    is_healthy BOOLEAN NOT NULL,
-    category_id BIGINT UNSIGNED NOT NULL
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(50) NOT NULL,
+	description VARCHAR(200) NOT NULL,
+	price INTEGER UNSIGNED NOT NULL,
+	is_uncertain BOOLEAN NOT NULL,
+	is_healthy BOOLEAN NOT NULL,
+	category_id BIGINT UNSIGNED NOT NULL
 )`
 
 	_, err := exec(c.DB, query)

--- a/storage/mariadb/dish_model.go
+++ b/storage/mariadb/dish_model.go
@@ -19,23 +19,29 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// CategoryModel is a storage.CategoryModel implementation.
-type CategoryModel struct {
+// DishModel is a storage.DishModel implementation.
+type DishModel struct {
 	DB *sqlx.DB
 }
 
 // Migrate implements storage.Model.Migrate.
-func (c CategoryModel) Migrate() error {
+func (c DishModel) Migrate() error {
 	query := `
-CREATE TABLE category (
+CREATE TABLE dish (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL
+    name VARCHAR(50) NOT NULL,
+    description VARCHAR(200) NOT NULL,
+    price INTEGER UNSIGNED NOT NULL,
+    is_uncertain BOOLEAN NOT NULL,
+    is_healthy BOOLEAN NOT NULL,
+    category_id BIGINT UNSIGNED NOT NULL
 )`
+
 	_, err := exec(c.DB, query)
 	return err
 }
 
 // Drop implements storage.Model.Drop.
-func (c CategoryModel) Drop() error {
-	return drop(c.DB, "category")
+func (c DishModel) Drop() error {
+	return drop(c.DB, "dish")
 }

--- a/storage/mariadb/dish_model.go
+++ b/storage/mariadb/dish_model.go
@@ -27,7 +27,7 @@ type DishModel struct {
 // Migrate implements storage.Model.Migrate.
 func (c DishModel) Migrate() error {
 	query := `
-CREATE TABLE dish (
+CREATE TABLE dishes (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) NOT NULL,
     description VARCHAR(200) NOT NULL,
@@ -43,5 +43,5 @@ CREATE TABLE dish (
 
 // Drop implements storage.Model.Drop.
 func (c DishModel) Drop() error {
-	return drop(c.DB, "dish")
+	return drop(c.DB, "dishes")
 }

--- a/storage/mariadb/offer_model.go
+++ b/storage/mariadb/offer_model.go
@@ -28,8 +28,8 @@ type OfferModel struct {
 func (c OfferModel) Migrate() error {
 	query := `
 CREATE TABLE offers (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    owner_user_id BIGINT UNSIGNED NOT NULL,
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	owner_user_id BIGINT UNSIGNED NOT NULL,
 	restaurant_id BIGINT UNSIGNED NOT NULL,
 	valid_from DATETIME NOT NULL,
 	valid_to DATETIME NOT NULL,

--- a/storage/mariadb/offer_model.go
+++ b/storage/mariadb/offer_model.go
@@ -19,29 +19,30 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// DishModel is a storage.DishModel implementation.
-type DishModel struct {
+// OfferModel is a storage.OfferModel implementation.
+type OfferModel struct {
 	DB *sqlx.DB
 }
 
 // Migrate implements storage.Model.Migrate.
-func (c DishModel) Migrate() error {
+func (c OfferModel) Migrate() error {
 	query := `
-CREATE TABLE dish (
+CREATE TABLE offer (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    description VARCHAR(200) NOT NULL,
-    price TINYINT UNSIGNED NOT NULL,
-    is_uncertain BOOLEAN NOT NULL,
-    is_healthy BOOLEAN NOT NULL,
-    category_id BIGINT UNSIGNED NOT NULL
+    owner_user_id BIGINT UNSIGNED NOT NULL,
+	restaurant_id BIGINT UNSIGNED NOT NULL,
+	valid_from DATETIME NOT NULL,
+	valid_to DATETIME NOT NULL,
+	responsible_user_id BIGINT UNSIGNED NOT NULL,
+	is_placed BOOLEAN NOT NULL,
+	ready_at DATETIME NOT NULL,
+	paypal_enabled BOOLEAN, NOT NULL
 )`
-
 	_, err := exec(c.DB, query)
 	return err
 }
 
 // Drop implements storage.Model.Drop.
-func (c DishModel) Drop() error {
-	return drop(c.DB, "dish")
+func (c OfferModel) Drop() error {
+	return drop(c.DB, "offer")
 }

--- a/storage/mariadb/offer_model.go
+++ b/storage/mariadb/offer_model.go
@@ -36,7 +36,7 @@ CREATE TABLE offer (
 	responsible_user_id BIGINT UNSIGNED NOT NULL,
 	is_placed BOOLEAN NOT NULL,
 	ready_at DATETIME NOT NULL,
-	paypal_enabled BOOLEAN, NOT NULL
+	paypal_enabled BOOLEAN NOT NULL
 )`
 	_, err := exec(c.DB, query)
 	return err

--- a/storage/mariadb/order_model.go
+++ b/storage/mariadb/order_model.go
@@ -28,10 +28,10 @@ type OrderModel struct {
 func (c OrderModel) Migrate() error {
 	query := `
 CREATE TABLE orders (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    user_id BIGINT UNSIGNED NOT NULL,
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	user_id BIGINT UNSIGNED NOT NULL,
 	is_paid BOOLEAN NOT NULL,
-    order_id BIGINT UNSIGNED NOT NULL
+	order_id BIGINT UNSIGNED NOT NULL
 )`
 	_, err := exec(c.DB, query)
 	return err

--- a/storage/mariadb/order_model.go
+++ b/storage/mariadb/order_model.go
@@ -27,7 +27,7 @@ type OrderModel struct {
 // Migrate implements storage.Model.Migrate.
 func (c OrderModel) Migrate() error {
 	query := `
-CREATE TABLE order (
+CREATE TABLE orders (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     user_id BIGINT UNSIGNED NOT NULL,
 	is_paid BOOLEAN NOT NULL,
@@ -39,5 +39,5 @@ CREATE TABLE order (
 
 // Drop implements storage.Model.Drop.
 func (c OrderModel) Drop() error {
-	return drop(c.DB, "order")
+	return drop(c.DB, "orders")
 }

--- a/storage/mariadb/order_model.go
+++ b/storage/mariadb/order_model.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The FoodUnit Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mariadb provides MariaDB-compatible model implementations.
+package mariadb
+
+import (
+	"github.com/jmoiron/sqlx"
+)
+
+// OrderModel is a storage.OrderModel implementation.
+type OrderModel struct {
+	DB *sqlx.DB
+}
+
+// Migrate implements storage.Model.Migrate.
+func (c OrderModel) Migrate() error {
+	query := `
+CREATE TABLE order (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT UNSIGNED NOT NULL,
+	is_paid BOOLEAN NOT NULL,
+    order_id BIGINT UNSIGNED NOT NULL
+)`
+	_, err := exec(c.DB, query)
+	return err
+}
+
+// Drop implements storage.Model.Drop.
+func (c OrderModel) Drop() error {
+	return drop(c.DB, "order")
+}

--- a/storage/mariadb/position_model.go
+++ b/storage/mariadb/position_model.go
@@ -28,8 +28,8 @@ type PositionModel struct {
 func (c PositionModel) Migrate() error {
 	query := `
 CREATE TABLE positions (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    dish_id BIGINT UNSIGNED NOT NULL,
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	dish_id BIGINT UNSIGNED NOT NULL,
 	alternative BIGINT UNSIGNED NOT NULL,
 	note VARCHAR(200) NOT NULL,
 	order_id BIGINT UNSIGNED NOT NULL

--- a/storage/mariadb/position_model.go
+++ b/storage/mariadb/position_model.go
@@ -19,30 +19,26 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// OfferModel is a storage.OfferModel implementation.
-type OfferModel struct {
+// PositionModel is a storage.PositionModel implementation.
+type PositionModel struct {
 	DB *sqlx.DB
 }
 
 // Migrate implements storage.Model.Migrate.
-func (c OfferModel) Migrate() error {
+func (c PositionModel) Migrate() error {
 	query := `
-CREATE TABLE offers (
+CREATE TABLE positions (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    owner_user_id BIGINT UNSIGNED NOT NULL,
-	restaurant_id BIGINT UNSIGNED NOT NULL,
-	valid_from DATETIME NOT NULL,
-	valid_to DATETIME NOT NULL,
-	responsible_user_id BIGINT UNSIGNED NOT NULL,
-	is_placed BOOLEAN NOT NULL,
-	ready_at DATETIME NOT NULL,
-	paypal_enabled BOOLEAN NOT NULL
+    dish_id BIGINT UNSIGNED NOT NULL,
+	alternative BIGINT UNSIGNED NOT NULL,
+	note VARCHAR(200) NOT NULL,
+	order_id BIGINT UNSIGNED NOT NULL
 )`
 	_, err := exec(c.DB, query)
 	return err
 }
 
 // Drop implements storage.Model.Drop.
-func (c OfferModel) Drop() error {
-	return drop(c.DB, "offers")
+func (c PositionModel) Drop() error {
+	return drop(c.DB, "positions")
 }

--- a/storage/mariadb/providers.go
+++ b/storage/mariadb/providers.go
@@ -94,3 +94,11 @@ func ProvideOrderModel(db *sqlx.DB) storage.OrderModel {
 	}
 	return &orderModel
 }
+
+// ProvidePositionModel provides a storage.PositionModel implementation.
+func ProvidePositionModel(db *sqlx.DB) storage.PositionModel {
+	positionModel := PositionModel{
+		DB: db,
+	}
+	return &positionModel
+}

--- a/storage/mariadb/providers.go
+++ b/storage/mariadb/providers.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The FoodUnit Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mariadb provides MariaDB-compatible model implementations.
+package mariadb
+
+import (
+	"github.com/dominikbraun/foodunit/storage"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
+
+// provideDB provides a ready-to-go database connection pool.
+func ProvideDBConnection(driver, dsn string) (*sqlx.DB, error) {
+	db, err := sqlx.Connect(driver, dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "connection failed")
+	}
+
+	return db, err
+}
+
+// provideRestaurantModel provides a storage.RestaurantModel implementation.
+func ProvideRestaurantModel(db *sqlx.DB) storage.RestaurantModel {
+	restaurantModel := RestaurantModel{
+		DB: db,
+	}
+	return &restaurantModel
+}
+
+// provideRestaurantModel provides a storage.RestaurantModel implementation.
+func ProvideUserModel(db *sqlx.DB) storage.UserModel {
+	userModel := UserModel{
+		DB: db,
+	}
+	return &userModel
+}

--- a/storage/mariadb/providers.go
+++ b/storage/mariadb/providers.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// provideDB provides a ready-to-go database connection pool.
+// ProvideDB provides a ready-to-go database connection pool.
 func ProvideDBConnection(driver, dsn string) (*sqlx.DB, error) {
 	db, err := sqlx.Connect(driver, dsn)
 	if err != nil {
@@ -31,7 +31,7 @@ func ProvideDBConnection(driver, dsn string) (*sqlx.DB, error) {
 	return db, err
 }
 
-// provideRestaurantModel provides a storage.RestaurantModel implementation.
+// ProvideRestaurantModel provides a storage.RestaurantModel implementation.
 func ProvideRestaurantModel(db *sqlx.DB) storage.RestaurantModel {
 	restaurantModel := RestaurantModel{
 		DB: db,
@@ -39,8 +39,16 @@ func ProvideRestaurantModel(db *sqlx.DB) storage.RestaurantModel {
 	return &restaurantModel
 }
 
-// provideRestaurantModel provides a storage.RestaurantModel implementation.
+// ProvideRestaurantModel provides a storage.RestaurantModel implementation.
 func ProvideUserModel(db *sqlx.DB) storage.UserModel {
+	userModel := UserModel{
+		DB: db,
+	}
+	return &userModel
+}
+
+// ProvideCategoryModel provides a storage.CategoryModel implementation.
+func ProvideCategoryModel(db *sqlx.DB) storage.UserModel {
 	userModel := UserModel{
 		DB: db,
 	}

--- a/storage/mariadb/providers.go
+++ b/storage/mariadb/providers.go
@@ -62,3 +62,27 @@ func ProvideDishModel(db *sqlx.DB) storage.DishModel {
 	}
 	return &dishModel
 }
+
+// ProvideCharacteristicModel provides a storage.CharacteristicModel implementation.
+func ProvideCharacteristicModel(db *sqlx.DB) storage.CharacteristicModel {
+	characteristicModel := CharacteristicModel{
+		DB: db,
+	}
+	return &characteristicModel
+}
+
+// ProvideVariantModel provides a storage.VariantModel implementation.
+func ProvideVariantModel(db *sqlx.DB) storage.VariantModel {
+	variantModel := VariantModel{
+		DB: db,
+	}
+	return &variantModel
+}
+
+// ProvideOfferModel provides a storage.OfferModel implementation.
+func ProvideOfferModel(db *sqlx.DB) storage.OfferModel {
+	offerModel := OfferModel{
+		DB: db,
+	}
+	return &offerModel
+}

--- a/storage/mariadb/providers.go
+++ b/storage/mariadb/providers.go
@@ -39,7 +39,7 @@ func ProvideRestaurantModel(db *sqlx.DB) storage.RestaurantModel {
 	return &restaurantModel
 }
 
-// ProvideRestaurantModel provides a storage.RestaurantModel implementation.
+// ProvideUserModel provides a storage.UserModel implementation.
 func ProvideUserModel(db *sqlx.DB) storage.UserModel {
 	userModel := UserModel{
 		DB: db,
@@ -48,9 +48,17 @@ func ProvideUserModel(db *sqlx.DB) storage.UserModel {
 }
 
 // ProvideCategoryModel provides a storage.CategoryModel implementation.
-func ProvideCategoryModel(db *sqlx.DB) storage.UserModel {
-	userModel := UserModel{
+func ProvideCategoryModel(db *sqlx.DB) storage.CategoryModel {
+	categoryModel := CategoryModel{
 		DB: db,
 	}
-	return &userModel
+	return &categoryModel
+}
+
+// ProvideDishModel provides a storage.DishModel implementation.
+func ProvideDishModel(db *sqlx.DB) storage.DishModel {
+	dishModel := DishModel{
+		DB: db,
+	}
+	return &dishModel
 }

--- a/storage/mariadb/providers.go
+++ b/storage/mariadb/providers.go
@@ -86,3 +86,11 @@ func ProvideOfferModel(db *sqlx.DB) storage.OfferModel {
 	}
 	return &offerModel
 }
+
+// ProvideOrderModel provides a storage.OrderModel implementation.
+func ProvideOrderModel(db *sqlx.DB) storage.OrderModel {
+	orderModel := OrderModel{
+		DB: db,
+	}
+	return &orderModel
+}

--- a/storage/mariadb/restaurant_model.go
+++ b/storage/mariadb/restaurant_model.go
@@ -29,19 +29,19 @@ type RestaurantModel struct {
 func (r RestaurantModel) Migrate() error {
 	query := `
 CREATE TABLE restaurants (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    postal_code VARCHAR(50) NOT NULL,
-    city VARCHAR(50) NOT NULL,
-    phone VARCHAR(50) NOT NULL,
-    open_mon VARCHAR(50) NOT NULL,
-    open_wed VARCHAR(50) NOT NULL,
-    open_thu VARCHAR(50) NOT NULL,
-    open_fri VARCHAR(50) NOT NULL,
-    open_sat VARCHAR(50) NOT NULL,
-    open_sun VARCHAR(50) NOT NULL,
-    website VARCHAR(50) NOT NULL,
-    is_active BOOLEAN NOT NULL
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	name VARCHAR(50) NOT NULL,
+	postal_code VARCHAR(50) NOT NULL,
+	city VARCHAR(50) NOT NULL,
+	phone VARCHAR(50) NOT NULL,
+	open_mon VARCHAR(50) NOT NULL,
+	open_wed VARCHAR(50) NOT NULL,
+	open_thu VARCHAR(50) NOT NULL,
+	open_fri VARCHAR(50) NOT NULL,
+	open_sat VARCHAR(50) NOT NULL,
+	open_sun VARCHAR(50) NOT NULL,
+	website VARCHAR(50) NOT NULL,
+	is_active BOOLEAN NOT NULL
 )`
 
 	_, err := exec(r.DB, query)

--- a/storage/mariadb/restaurant_model.go
+++ b/storage/mariadb/restaurant_model.go
@@ -25,12 +25,9 @@ type RestaurantModel struct {
 	DB *sqlx.DB
 }
 
-// Migrate implements storage.RestaurantModel.Migrate.
+// Migrate implements storage.Model.Migrate.
 func (r RestaurantModel) Migrate() error {
-	query := `drop table if exists restaurants`
-	_ = r.DB.MustExec(query)
-
-	query = `
+	query := `
 CREATE TABLE restaurants (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) NOT NULL,
@@ -47,8 +44,13 @@ CREATE TABLE restaurants (
     is_active BOOLEAN NOT NULL
 )`
 
-	_ = r.DB.MustExec(query)
-	return nil
+	_, err := r.DB.Exec(query)
+	return err
+}
+
+// Drop implements storage.Model.Drop.
+func (r RestaurantModel) Drop() error {
+	return drop(r.DB, "restaurants")
 }
 
 // GetInfo implements storage.RestaurantModel.GetInfo.

--- a/storage/mariadb/restaurant_model.go
+++ b/storage/mariadb/restaurant_model.go
@@ -44,7 +44,7 @@ CREATE TABLE restaurants (
     is_active BOOLEAN NOT NULL
 )`
 
-	_, err := r.DB.Exec(query)
+	_, err := exec(r.DB, query)
 	return err
 }
 

--- a/storage/mariadb/sql.go
+++ b/storage/mariadb/sql.go
@@ -1,0 +1,10 @@
+package mariadb
+
+import "github.com/jmoiron/sqlx"
+
+func drop(db *sqlx.DB, table string) error {
+	query := `drop table if exists ` + table
+	// ToDo: check for affected rows? (return error if 0?)
+	_, err := db.Exec(query)
+	return err
+}

--- a/storage/mariadb/sql.go
+++ b/storage/mariadb/sql.go
@@ -1,10 +1,21 @@
 package mariadb
 
-import "github.com/jmoiron/sqlx"
+import (
+	"database/sql"
+	"github.com/jmoiron/sqlx"
+	"github.com/pkg/errors"
+)
 
+// drops a table
 func drop(db *sqlx.DB, table string) error {
 	query := `drop table if exists ` + table
 	// ToDo: check for affected rows? (return error if 0?)
-	_, err := db.Exec(query)
+	_, err := exec(db, query)
 	return err
+}
+
+// wraps DB.Exec and adds more error information in case of an error
+func exec(db *sqlx.DB, query string, args ...interface{}) (sql.Result, error) {
+	res, err := db.Exec(query)
+	return res, errors.Wrap(err, query)
 }

--- a/storage/mariadb/sql.go
+++ b/storage/mariadb/sql.go
@@ -8,7 +8,7 @@ import (
 
 // drops a table
 func drop(db *sqlx.DB, table string) error {
-	query := `drop table if exists ` + table
+	query := `DROP TABLE IF EXISTS ` + table
 	// ToDo: check for affected rows? (return error if 0?)
 	_, err := exec(db, query)
 	return err

--- a/storage/mariadb/user_model.go
+++ b/storage/mariadb/user_model.go
@@ -44,7 +44,7 @@ CREATE TABLE users (
     created DATETIME NOT NULL
 )`
 
-	_, err := u.DB.Exec(query)
+	_, err := exec(u.DB, query)
 	return err
 }
 
@@ -61,7 +61,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)`
 
 	created := user.Created.Format(DateTime)
 
-	_, err := u.DB.Exec(query, user.MailAddr, user.Name, user.IsAdmin, user.PaypalMailAddr, user.Score, user.PasswordHash, created)
+	_, err := exec(u.DB, query, user.MailAddr, user.Name, user.IsAdmin, user.PaypalMailAddr, user.Score, user.PasswordHash, created)
 	if err != nil {
 		return err
 	}

--- a/storage/mariadb/user_model.go
+++ b/storage/mariadb/user_model.go
@@ -32,14 +32,14 @@ type UserModel struct {
 func (u UserModel) Migrate() error {
 	query := `
 CREATE TABLE users (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    mail_addr VARCHAR(254) NOT NULL,
-    name VARCHAR(50) NOT NULL,
-    is_admin BOOLEAN NOT NULL,
-    paypal_mail_addr VARCHAR(254) NOT NULL,
-    score INTEGER NOT NULL,
-    password_hash CHAR(60) NOT NULL,
-    created DATETIME NOT NULL
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	mail_addr VARCHAR(254) NOT NULL,
+	name VARCHAR(50) NOT NULL,
+	is_admin BOOLEAN NOT NULL,
+	paypal_mail_addr VARCHAR(254) NOT NULL,
+	score INTEGER NOT NULL,
+	password_hash CHAR(60) NOT NULL,
+	created DATETIME NOT NULL
 )`
 
 	_, err := exec(u.DB, query)

--- a/storage/mariadb/user_model.go
+++ b/storage/mariadb/user_model.go
@@ -30,12 +30,9 @@ type UserModel struct {
 	DB *sqlx.DB
 }
 
-// Migrate implements storage.UserModel.Migrate.
+// Migrate implements storage.Model.Migrate.
 func (u UserModel) Migrate() error {
-	query := `drop table if exists users`
-	_ = u.DB.MustExec(query)
-
-	query = `
+	query := `
 CREATE TABLE users (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     mail_addr VARCHAR(254) NOT NULL,
@@ -47,8 +44,13 @@ CREATE TABLE users (
     created DATETIME NOT NULL
 )`
 
-	_ = u.DB.MustExec(query)
-	return nil
+	_, err := u.DB.Exec(query)
+	return err
+}
+
+// Drop implements storage.Model.Drop.
+func (u UserModel) Drop() error {
+	return drop(u.DB, "users")
 }
 
 // Create implements storage.UserModel.Create.

--- a/storage/mariadb/variant_model.go
+++ b/storage/mariadb/variant_model.go
@@ -19,29 +19,25 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// DishModel is a storage.DishModel implementation.
-type DishModel struct {
+// VariantModel is a storage.VariantModel implementation.
+type VariantModel struct {
 	DB *sqlx.DB
 }
 
 // Migrate implements storage.Model.Migrate.
-func (c DishModel) Migrate() error {
+func (c VariantModel) Migrate() error {
 	query := `
-CREATE TABLE dish (
+CREATE TABLE variant (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(50) NOT NULL,
-    description VARCHAR(200) NOT NULL,
-    price TINYINT UNSIGNED NOT NULL,
-    is_uncertain BOOLEAN NOT NULL,
-    is_healthy BOOLEAN NOT NULL,
-    category_id BIGINT UNSIGNED NOT NULL
+    value VARCHAR(50) NOT NULL,
+	is_default BOOLEAN NOT NULL,
+    price TINYINT UNSIGNED NOT NULL
 )`
-
 	_, err := exec(c.DB, query)
 	return err
 }
 
 // Drop implements storage.Model.Drop.
-func (c DishModel) Drop() error {
-	return drop(c.DB, "dish")
+func (c VariantModel) Drop() error {
+	return drop(c.DB, "variant")
 }

--- a/storage/mariadb/variant_model.go
+++ b/storage/mariadb/variant_model.go
@@ -27,7 +27,7 @@ type VariantModel struct {
 // Migrate implements storage.Model.Migrate.
 func (c VariantModel) Migrate() error {
 	query := `
-CREATE TABLE variant (
+CREATE TABLE variants (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     value VARCHAR(50) NOT NULL,
 	is_default BOOLEAN NOT NULL,
@@ -39,5 +39,5 @@ CREATE TABLE variant (
 
 // Drop implements storage.Model.Drop.
 func (c VariantModel) Drop() error {
-	return drop(c.DB, "variant")
+	return drop(c.DB, "variants")
 }

--- a/storage/mariadb/variant_model.go
+++ b/storage/mariadb/variant_model.go
@@ -28,10 +28,10 @@ type VariantModel struct {
 func (c VariantModel) Migrate() error {
 	query := `
 CREATE TABLE variants (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    value VARCHAR(50) NOT NULL,
+	id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+	value VARCHAR(50) NOT NULL,
 	is_default BOOLEAN NOT NULL,
-    price TINYINT UNSIGNED NOT NULL
+	price INTEGER UNSIGNED NOT NULL
 )`
 	_, err := exec(c.DB, query)
 	return err

--- a/storage/models.go
+++ b/storage/models.go
@@ -35,3 +35,11 @@ type UserModel interface {
 	FindByMailAddr(mailAddr string) (dl.User, error)
 	Exists(mailAddr string) (bool, error)
 }
+
+type CategoryModel interface {
+	Model
+}
+
+type DishModel interface {
+	Model
+}

--- a/storage/models.go
+++ b/storage/models.go
@@ -43,3 +43,15 @@ type CategoryModel interface {
 type DishModel interface {
 	Model
 }
+
+type CharacteristicModel interface {
+	Model
+}
+
+type VariantModel interface {
+	Model
+}
+
+type OfferModel interface {
+	Model
+}

--- a/storage/models.go
+++ b/storage/models.go
@@ -17,14 +17,19 @@ package storage
 
 import "github.com/dominikbraun/foodunit/dl"
 
+type Model interface {
+	Migrate() error
+	Drop() error
+}
+
 // RestaurantModel prescribes methods for accessing Restaurant-related data.
 type RestaurantModel interface {
-	Migrate() error
+	Model
 	GetInfo(id uint64) (dl.Restaurant, error)
 }
 
 type UserModel interface {
-	Migrate() error
+	Model
 	Create(user dl.User) error
 	Authenticate(mailAddr, password string) (int, error)
 	FindByMailAddr(mailAddr string) (dl.User, error)

--- a/storage/models.go
+++ b/storage/models.go
@@ -55,3 +55,7 @@ type VariantModel interface {
 type OfferModel interface {
 	Model
 }
+
+type OrderModel interface {
+	Model
+}

--- a/storage/models.go
+++ b/storage/models.go
@@ -59,3 +59,7 @@ type OfferModel interface {
 type OrderModel interface {
 	Model
 }
+
+type PositionModel interface {
+	Model
+}


### PR DESCRIPTION
This PR
- moves providers to the respective packages (e.g. maria-db-providers to mariadb)
- adds a controller for migration handling
- adds all models (based on current entities)